### PR TITLE
Fetch and display previous item orders

### DIFF
--- a/www/database/migrations/2025_09_21_120000_add_indexes_for_price_history.php
+++ b/www/database/migrations/2025_09_21_120000_add_indexes_for_price_history.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            // For product-level filtering
+            $table->index(['product_id', 'status']);
+        });
+
+        Schema::table('orders', function (Blueprint $table) {
+            // For customer and date sorting
+            $table->index(['customer_id', 'order_date']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropIndex(['product_id', 'status']);
+        });
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropIndex(['customer_id', 'order_date']);
+        });
+    }
+};
+

--- a/www/routes/web.php
+++ b/www/routes/web.php
@@ -68,6 +68,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::resource('product-brands', ProductBrandController::class);
     
     // Order routes
+    Route::get('orders/price-history', [OrderController::class, 'priceHistory'])->name('orders.price-history');
     Route::resource('orders', OrderController::class);
     Route::get('orders/{order}/convert-to-sale', [OrderController::class, 'convertToSale'])->name('orders.convert-to-sale');
     Route::post('orders/{order}/convert', [OrderController::class, 'convertToSale'])->name('orders.convert');


### PR DESCRIPTION
Adds a price history popup to the order creation page, showing a customer's past item purchases and prices to aid in pricing decisions.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed59e0f1-7a0d-45dd-a0ae-a7efe0ff03b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed59e0f1-7a0d-45dd-a0ae-a7efe0ff03b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

