### PR TITLE
Implement unit of measure quantity management

### DIFF
--- a/www/app/Models/Uom.php
+++ b/www/app/Models/Uom.php
@@ -18,6 +18,10 @@ class Uom extends Model
         'code',
         'description',
         'units_per_uom',
+        'dimension_code',
+        'factor_to_base',
+        'offset_to_base',
+        'min_increment',
         'created_by',
         'updated_by',
         'status',
@@ -27,6 +31,9 @@ class Uom extends Model
     {
         return [
             'units_per_uom' => 'integer',
+            'factor_to_base' => 'decimal:12',
+            'offset_to_base' => 'decimal:12',
+            'min_increment' => 'decimal:12',
             'status' => 'integer',
         ];
     }

--- a/www/app/Services/UomService.php
+++ b/www/app/Services/UomService.php
@@ -6,6 +6,14 @@ use App\Models\Uom;
 
 class UomService
 {
+    /**
+     * Convert a line input to base units.
+     *
+     * Semantics (Option A):
+     * - If a uomId is provided, treat `quantity` as the count of that UOM (packs),
+     *   and ignore uomQuantity. Base = quantity * units_per_uom.
+     * - If no uomId, base = quantity (already base each).
+     */
     public static function toBaseUnits(int $quantity, ?int $uomId, ?int $uomQuantity = 1): int
     {
         if (!$uomId) {
@@ -15,9 +23,52 @@ class UomService
         if (!$uom) {
             return (int) $quantity;
         }
-        $multiplier = max(1, (int) $uom->units_per_uom);
-        $uomQty = max(1, (int) ($uomQuantity ?? 1));
-        return (int) ($uomQty * $multiplier);
+        $unitsPerUom = max(1, (int) $uom->units_per_uom);
+        $packsCount = max(0, (int) $quantity);
+        return (int) ($packsCount * $unitsPerUom);
+    }
+
+    /**
+     * Generic conversion using factor/offset between any two UOMs in the same dimension.
+     */
+    public static function convert(float $value, int $fromUomId, int $toUomId): float
+    {
+        $from = Uom::find($fromUomId);
+        $to = Uom::find($toUomId);
+        if (!$from || !$to) {
+            throw new \InvalidArgumentException('Invalid UOM');
+        }
+        if (($from->dimension_code ?? 'count') !== ($to->dimension_code ?? 'count')) {
+            throw new \InvalidArgumentException('Dimension mismatch');
+        }
+        // Affine to base
+        $base = ($value + (float) $from->offset_to_base) * (float) $from->factor_to_base;
+        // From base to target
+        return ($base / (float) $to->factor_to_base) - (float) $to->offset_to_base;
+    }
+
+    /**
+     * Convert from a UOM to its base (factor/offset aware). Returns float value in base unit of the dimension.
+     */
+    public static function toBaseValue(float $value, int $fromUomId): float
+    {
+        $from = Uom::find($fromUomId);
+        if (!$from) {
+            throw new \InvalidArgumentException('Invalid UOM');
+        }
+        return ($value + (float) $from->offset_to_base) * (float) $from->factor_to_base;
+    }
+
+    /**
+     * Convert a base value to a target UOM (factor/offset aware).
+     */
+    public static function fromBaseValue(float $baseValue, int $toUomId): float
+    {
+        $to = Uom::find($toUomId);
+        if (!$to) {
+            throw new \InvalidArgumentException('Invalid UOM');
+        }
+        return ($baseValue / (float) $to->factor_to_base) - (float) $to->offset_to_base;
     }
 }
 

--- a/www/database/migrations/2025_09_22_200500_extend_uoms_with_dimensions_and_factors.php
+++ b/www/database/migrations/2025_09_22_200500_extend_uoms_with_dimensions_and_factors.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('uoms', function (Blueprint $table) {
+            if (!Schema::hasColumn('uoms', 'dimension_code')) {
+                $table->string('dimension_code', 30)->default('count')->after('units_per_uom');
+            }
+            if (!Schema::hasColumn('uoms', 'factor_to_base')) {
+                $table->decimal('factor_to_base', 24, 12)->default(1)->after('dimension_code');
+            }
+            if (!Schema::hasColumn('uoms', 'offset_to_base')) {
+                $table->decimal('offset_to_base', 24, 12)->default(0)->after('factor_to_base');
+            }
+            if (!Schema::hasColumn('uoms', 'min_increment')) {
+                $table->decimal('min_increment', 24, 12)->nullable()->after('offset_to_base');
+            }
+            $table->index('dimension_code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('uoms', function (Blueprint $table) {
+            try { $table->dropIndex(['dimension_code']); } catch (\Throwable $e) {}
+            try { $table->dropColumn(['dimension_code', 'factor_to_base', 'offset_to_base', 'min_increment']); } catch (\Throwable $e) {}
+        });
+    }
+};
+


### PR DESCRIPTION
Extend the `uoms` table with dimension and conversion fields, and refactor `SaleController` to use an enhanced `UomService` for base quantity calculation.

This change lays the foundation for supporting physical units and affine conversions, while immediately fixing an inconsistency in sales quantity calculation by treating the input `quantity` as the number of UOM packs (Option A from the discussion).

---
<a href="https://cursor.com/background-agent?bcId=bc-6e6d5c2b-e68c-4422-8553-307211d1727a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e6d5c2b-e68c-4422-8553-307211d1727a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

