### PR TITLE
Fix missing sku column in sales reports

### DIFF
--- a/www/app/Http/Controllers/ReportsController.php
+++ b/www/app/Http/Controllers/ReportsController.php
@@ -87,7 +87,7 @@ class ReportsController extends Controller
         // Best seller analysis
         $bestSellers = DB::table('sale_items')
             ->join('products', 'sale_items.product_id', '=', 'products.id')
-            ->select('products.name', 'products.sku', DB::raw('SUM(sale_items.quantity) as total_quantity'), DB::raw('SUM(sale_items.total_price) as total_revenue'))
+            ->select('products.name', 'products.stockref', DB::raw('SUM(sale_items.quantity) as total_quantity'), DB::raw('SUM(sale_items.total_price) as total_revenue'))
             ->when($request->filled('period'), function($query) use ($request) {
                 switch ($request->period) {
                     case 'this_month':
@@ -110,7 +110,7 @@ class ReportsController extends Controller
                         return $query;
                 }
             })
-            ->groupBy('products.id', 'products.name', 'products.sku')
+            ->groupBy('products.id', 'products.name', 'products.stockref')
             ->orderBy('total_quantity', 'desc')
             ->limit(10)
             ->get();
@@ -204,7 +204,7 @@ class ReportsController extends Controller
         // Stock movement analysis
         $stockMovements = DB::table('stock_movements')
             ->join('products', 'stock_movements.product_id', '=', 'products.id')
-            ->select('products.name', 'products.sku', 
+            ->select('products.name', 'products.stockref', 
                     DB::raw('SUM(CASE WHEN type = "in" THEN quantity ELSE 0 END) as total_in'),
                     DB::raw('SUM(CASE WHEN type = "out" THEN quantity ELSE 0 END) as total_out'))
             ->when($request->filled('date_from'), function($query) use ($request) {
@@ -213,7 +213,7 @@ class ReportsController extends Controller
             ->when($request->filled('date_to'), function($query) use ($request) {
                 return $query->whereDate('stock_movements.created_at', '<=', $request->date_to);
             })
-            ->groupBy('products.id', 'products.name', 'products.sku')
+            ->groupBy('products.id', 'products.name', 'products.stockref')
             ->orderBy('total_in', 'desc')
             ->get();
 

--- a/www/resources/views/dashboard.blade.php
+++ b/www/resources/views/dashboard.blade.php
@@ -193,7 +193,7 @@
                                 </div>
                                 <div>
                                     <div class="text-sm font-medium text-gray-900">{{ $product->name }}</div>
-                                    <div class="text-sm text-gray-500">{{ $product->sku }}</div>
+                                    <div class="text-sm text-gray-500">{{ $product->stockref }}</div>
                                 </div>
                             </div>
                         </td>

--- a/www/resources/views/inventory/create.blade.php
+++ b/www/resources/views/inventory/create.blade.php
@@ -18,7 +18,7 @@
                             <option value="">Select a product</option>
                             @foreach($products as $product)
                                 <option value="{{ $product->id }}" {{ old('product_id') == $product->id ? 'selected' : '' }}>
-                                    {{ $product->name }} ({{ $product->sku }})
+                                    {{ $product->name }} ({{ $product->stockref }})
                                 </option>
                             @endforeach
                         </select>

--- a/www/resources/views/inventory/edit.blade.php
+++ b/www/resources/views/inventory/edit.blade.php
@@ -21,7 +21,7 @@
                             </div>
                             <div>
                                 <div class="text-sm font-medium text-gray-900">{{ $inventory->product->name }}</div>
-                                <div class="text-sm text-gray-500">{{ $inventory->product->sku }}</div>
+                                <div class="text-sm text-gray-500">{{ $inventory->product->stockref }}</div>
                             </div>
                         </div>
                     </div>

--- a/www/resources/views/inventory/index.blade.php
+++ b/www/resources/views/inventory/index.blade.php
@@ -117,7 +117,7 @@
                                         </div>
                                         <div>
                                             <div class="text-sm font-medium text-gray-900">{{ $item->product->name }}</div>
-                                            <div class="text-sm text-gray-500">{{ $item->product->sku }}</div>
+                                            <div class="text-sm text-gray-500">{{ $item->product->stockref }}</div>
                                         </div>
                                     </div>
                                 </td>

--- a/www/resources/views/inventory/low-stock.blade.php
+++ b/www/resources/views/inventory/low-stock.blade.php
@@ -62,7 +62,7 @@
                                         </div>
                                         <div>
                                             <div class="text-sm font-medium text-gray-900">{{ $item->product->name }}</div>
-                                            <div class="text-sm text-gray-500">{{ $item->product->sku }}</div>
+                                            <div class="text-sm text-gray-500">{{ $item->product->stockref }}</div>
                                         </div>
                                     </div>
                                 </td>

--- a/www/resources/views/inventory/show.blade.php
+++ b/www/resources/views/inventory/show.blade.php
@@ -34,7 +34,7 @@
                             </div>
                             <div>
                                 <div class="text-sm font-medium text-gray-900">{{ $inventory->product->name }}</div>
-                                <div class="text-sm text-gray-500">{{ $inventory->product->sku }}</div>
+                                <div class="text-sm text-gray-500">{{ $inventory->product->stockref }}</div>
                             </div>
                         </div>
                     </div>

--- a/www/resources/views/inventory/stock-report.blade.php
+++ b/www/resources/views/inventory/stock-report.blade.php
@@ -157,7 +157,7 @@
                                     </div>
                                     <div>
                                         <div class="text-sm font-medium text-gray-900">{{ $item->product->name }}</div>
-                                        <div class="text-sm text-gray-500">{{ $item->product->sku }}</div>
+                                        <div class="text-sm text-gray-500">{{ $item->product->stockref }}</div>
                                     </div>
                                 </div>
                             </td>

--- a/www/resources/views/orders/show.blade.php
+++ b/www/resources/views/orders/show.blade.php
@@ -301,7 +301,7 @@
                             <tr>
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     <div class="text-sm font-medium text-gray-900">{{ $item->product->name }}</div>
-                                    <div class="text-sm text-gray-500">{{ $item->product->sku }}</div>
+                                    <div class="text-sm text-gray-500">{{ $item->product->stockref }}</div>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     <div class="text-sm text-gray-900">{{ $item->product->category->name ?? 'N/A' }}</div>

--- a/www/resources/views/products/show.blade.php
+++ b/www/resources/views/products/show.blade.php
@@ -64,10 +64,10 @@
                             <dd class="mt-1 text-sm text-gray-900">{{ $product->brand->name ?? 'No brand' }}</dd>
                         </div>
                         
-                        @if($product->sku)
+                        @if($product->stockref)
                             <div>
                                 <dt class="text-sm font-medium text-gray-500">SKU</dt>
-                                <dd class="mt-1 text-sm text-gray-900 font-mono">{{ $product->sku }}</dd>
+                                <dd class="mt-1 text-sm text-gray-900 font-mono">{{ $product->stockref }}</dd>
                             </div>
                         @endif
                         

--- a/www/resources/views/reports/inventory.blade.php
+++ b/www/resources/views/reports/inventory.blade.php
@@ -175,7 +175,7 @@
                             {{ $item->product->name }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            {{ $item->product->sku }}
+                            {{ $item->product->stockref }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                             {{ number_format($item->current_stock) }}
@@ -249,7 +249,7 @@
                             {{ $movement->name }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            {{ $movement->sku }}
+                            {{ $movement->stockref }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-green-600">
                             {{ number_format($movement->total_in) }}

--- a/www/resources/views/reports/sales.blade.php
+++ b/www/resources/views/reports/sales.blade.php
@@ -222,7 +222,7 @@
                             {{ $product->name }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                            {{ $product->sku }}
+                            {{ $product->stockref }}
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
                             {{ number_format($product->total_quantity) }}

--- a/www/resources/views/sales/show.blade.php
+++ b/www/resources/views/sales/show.blade.php
@@ -262,7 +262,7 @@
                             <tr>
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     <div class="text-sm font-medium text-gray-900">{{ $item->product->name }}</div>
-                                    <div class="text-sm text-gray-500">{{ $item->product->sku }}</div>
+                                    <div class="text-sm text-gray-500">{{ $item->product->stockref }}</div>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $item->quantity }}</td>
                                 <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">Rs {{ number_format($item->unit_price, 2) }}</td>


### PR DESCRIPTION
Replace `products.sku` with `products.stockref` to resolve "Column not found" SQL errors in reports and other views.

The `products` table in the database uses `stockref` as the product identifier, but various parts of the application were incorrectly referencing `products.sku`, leading to `SQLSTATE[42S22]: Column not found` errors. This PR corrects all these inconsistencies across the controller and multiple Blade views.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c653edb-c927-423e-bd6b-4690188f69ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c653edb-c927-423e-bd6b-4690188f69ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

